### PR TITLE
Fix font scanning to include uppercase extensions

### DIFF
--- a/figlet_font_browser.py
+++ b/figlet_font_browser.py
@@ -76,12 +76,16 @@ class FontEntry:
 
 def scan_fonts(base: Path) -> List[FontEntry]:
   fonts: List[FontEntry] = []
-  for p in base.rglob("*.flf"):
-    if p.is_file():
+
+  for p in base.rglob("*"):
+    if not p.is_file():
+      continue
+    suffix = p.suffix.lower()
+    if suffix == ".flf":
       fonts.append(FontEntry(p, "flf"))
-  for p in base.rglob("*.tlf"):
-    if p.is_file():
+    elif suffix == ".tlf":
       fonts.append(FontEntry(p, "tlf"))
+
   fonts.sort(key=lambda f: str(f.path).lower())
   return fonts
 


### PR DESCRIPTION
## Summary
- update font directory scan to treat file extensions case-insensitively
- ensure .flf and .tlf fonts with uppercase extensions appear in the browser list

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df7c6d550c832c9d0d3defe7c6e3b2