### PR TITLE
Add compare-output mode to deduplicate by FIGlet rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@
 Copy FIGlet fonts (`.flf`, `.tlf`) from an input directory to an output directory with:
 
 - **Content-based de-duplication** across the entire `--out` tree (recursive).
+- Optional **rendered-output de-duplication** (`--compare-output`) that hashes the FIGlet output for a sample string (requires the
+  `figlet` CLI) so visually identical fonts are treated as duplicates.
 - **Versioned renaming** for same-name / different-content files (`_v02`, `_v03`, …).
 - Optional **recursive** scanning of `--in`.
 - Optional **outsub** routing (`--outsub`) to group this run’s copies into a subfolder.
@@ -50,4 +52,10 @@ pip install rich xxhash
 
 # 3) run
 python figlet_font_curator.py --in ./fonts_in --out ./fonts_out
+
+```
+
+> **Tip:** To de-duplicate based on rendered FIGlet output, install the `figlet` CLI (for example, `apt-get install figlet` on
+> Debian/Ubuntu) and add `--compare-output` when running the curator. The tool will render the sample string `FIGLET FONT CURATOR`
+> with each font to detect visually identical results.
 


### PR DESCRIPTION
## Summary
- add a `--compare-output` flag that fingerprints fonts by their FIGlet rendering of a sample string and shares the result across imports
- ensure the CLI refuses the flag when the `figlet` executable is missing and log the chosen comparison mode
- document the new capability and usage tip in the README

## Testing
- python -m compileall figlet_font_curator.py

------
https://chatgpt.com/codex/tasks/task_e_68df956f97cc832ca763fd8e4e1a8d3f